### PR TITLE
Raise 400 for invalid query param values

### DIFF
--- a/data_gov_my/views.py
+++ b/data_gov_my/views.py
@@ -18,7 +18,7 @@ from django.contrib.postgres.search import SearchVector
 from django.contrib.postgres.search import SearchHeadline
 from data_gov_my.serializers import i18nSerializer
 from django.shortcuts import get_object_or_404, get_list_or_404
-
+from rest_framework.exceptions import ParseError
 
 from data_gov_my.utils import cron_utils, triggers
 from data_gov_my.models import MetaJson, DashboardJson, CatalogJson, NameDashboard_FirstName, NameDashboard_LastName, i18nJson
@@ -470,6 +470,9 @@ def get_nested_data(api_params, param_list, data):
             )
             if key in data:
                 data = data[key]
+            else:
+                raise ParseError(
+                    detail=f'The {a} \'{key}\' is invalid. Please use a valid {a}.')
         else:
             data = {}
             break


### PR DESCRIPTION
## Changes made
1. Per FE request, invalid query parameter values (e.g. ...?key=gibberish) should raise an error instead of returning the full data. 

Sample:
![image](https://user-images.githubusercontent.com/42997224/236977134-d8aca4d5-971d-4b47-b7e0-2ca1cb4fdfb5.png)
![image](https://user-images.githubusercontent.com/42997224/236977163-e0a3b13d-b202-4187-b6df-244e24ba02e7.png)
