### PR TITLE
fix: keyerror and noneerror

### DIFF
--- a/data_gov_my/catalog_utils/catalog_variable_classes/Barv2.py
+++ b/data_gov_my/catalog_utils/catalog_variable_classes/Barv2.py
@@ -1,9 +1,8 @@
-from data_gov_my.catalog_utils.catalog_variable_classes.Generalv2 import GeneralChartsUtil
-
+from data_gov_my.catalog_utils.catalog_variable_classes.Generalv2 import (
+    GeneralChartsUtil,
+)
 import pandas as pd
 import numpy as np
-import json
-from dateutil.relativedelta import relativedelta
 from mergedeep import merge
 
 
@@ -26,10 +25,12 @@ class Bar(GeneralChartsUtil):
     """
 
     def __init__(self, full_meta, file_data, cur_data, all_variable_data, file_src):
-        GeneralChartsUtil.__init__(self, full_meta, file_data, cur_data, all_variable_data, file_src)
+        GeneralChartsUtil.__init__(
+            self, full_meta, file_data, cur_data, all_variable_data, file_src
+        )
 
         # Sets API details
-        self.chart_type = self.chart['chart_type']
+        self.chart_type = self.chart["chart_type"]
         self.api_filter = self.chart["chart_filters"]["SLICE_BY"]
         self.api = self.build_api_info()
 
@@ -47,51 +48,51 @@ class Bar(GeneralChartsUtil):
     """
     Chart builder version 2
     """
-    def chart_v2(self) :
+
+    def chart_v2(self):
         result = {}
 
         df = pd.read_parquet(self.read_from)
 
-        if 'date' in df.columns : 
-            self.b_keys.insert(0, 'date')
+        if "date" in df.columns:
+            self.b_keys.insert(0, "date")
 
-        if len(self.b_keys) > 0 : 
+        if len(self.b_keys) > 0:
             result = self.build_chart_parents()
-        else : 
+        else:
             result = self.build_chart_self()
 
         return result
 
-
     """
     Builds chart data with 0 nested keys
     """
-    def build_chart_self(self) :
+
+    def build_chart_self(self):
         df = pd.read_parquet(self.read_from)
 
-        if "STACKED" in self.chart_type : 
+        if "STACKED" in self.chart_type:
             df = self.abs_to_perc(df)
-        
-        df = df.replace({np.nan: None}) 
 
-        c_vals = {} # Chart Values
-        t_vals = {} # Table Values
+        df = df.replace({np.nan: None})
+
+        c_vals = {}  # Chart Values
+        t_vals = {}  # Table Values
 
         rename_cols = {}
-        rename_cols[self.b_x] = 'x'
+        rename_cols[self.b_x] = "x"
 
-        c_vals['x'] = df[self.b_x].to_list()
+        c_vals["x"] = df[self.b_x].to_list()
 
         for index, y in enumerate(self.b_y):
             y_list = df[y].to_list()
             y_val = f"y{ index + 1 }"
             rename_cols[y] = y_val
             c_vals[y_val] = y_list
-        
-        t_vals = (
-            df.rename(columns=rename_cols)[list(rename_cols.values())]
-            .to_dict("records")
-        )        
+
+        t_vals = df.rename(columns=rename_cols)[list(rename_cols.values())].to_dict(
+            "records"
+        )
 
         overall = {}
         overall["chart_data"] = c_vals
@@ -106,18 +107,18 @@ class Bar(GeneralChartsUtil):
     def build_chart_parents(self):
         df = pd.read_parquet(self.read_from)
 
-        if "STACKED" in self.chart_type : 
+        if "STACKED" in self.chart_type:
             df = self.abs_to_perc(df)
 
-        df = df.replace({np.nan: None}) 
-        
-        # Converts all values to : 
+        df = df.replace({np.nan: None})
+
+        # Converts all values to :
         # - A str if its an object
         # - A str with lowercase, and spaces as hyphen
 
         for key in self.b_keys:
-            if df[key].dtype == "object" :
-                df[key] = df[key].astype(str)            
+            if df[key].dtype == "object":
+                df[key] = df[key].astype(str)
             df[key] = df[key].apply(lambda x: x.lower().replace(" ", "-"))
 
         # Gets all unique groups
@@ -137,13 +138,13 @@ class Bar(GeneralChartsUtil):
                 tbl = {b: tbl}
             group_l = list(group)
 
-            if len(group) == 1 : 
+            if len(group) == 1:
                 group = group[0]
-            
+
             x_list = df.groupby(self.b_keys)[self.b_x].get_group(group).to_list()
 
-            rename_columns = {self.b_x: "x"} # Dict to rename columns for table
-            chart_vals = {"x": x_list} # Extracted chart values
+            rename_columns = {self.b_x: "x"}  # Dict to rename columns for table
+            chart_vals = {"x": x_list}  # Extracted chart values
 
             # Gets y-values for chart
             for index, y in enumerate(self.b_y):
@@ -175,17 +176,18 @@ class Bar(GeneralChartsUtil):
     """
     Set table columns
     """
-    def set_table_columns(self) :
+
+    def set_table_columns(self):
         res = {}
 
         res["en"] = {}
         res["bm"] = {}
 
         if self.table_translation:
-            res['en']['x'] = self.table_translation["en"]["x"]
-            res['bm']['x'] = self.table_translation["bm"]["x"]
+            res["en"]["x"] = self.table_translation["en"]["x"]
+            res["bm"]["x"] = self.table_translation["bm"]["x"]
 
-            for y_lang in ["en", "bm"] :
+            for y_lang in ["en", "bm"]:
                 y_list = self.table_translation[y_lang]["y"]
                 for index, c_y in enumerate(y_list):
                     y_val = f"y{ index + 1}"
@@ -199,7 +201,7 @@ class Bar(GeneralChartsUtil):
                     y_val = f"y{ index + 1}"
                     res[y_lang][y_val] = y
 
-        return res       
+        return res
 
     """
     Builds the API info for Bar
@@ -211,7 +213,7 @@ class Bar(GeneralChartsUtil):
         df = pd.read_parquet(self.read_from)
         api_filters_inc = []
 
-        if 'date' in df.columns :
+        if "date" in df.columns:
             slider_obj = self.build_date_slider(df)
             api_filters_inc.append(slider_obj)
 
@@ -230,49 +232,52 @@ class Bar(GeneralChartsUtil):
         res["API"]["filters"] = api_filters_inc
         res["API"]["precision"] = self.precision
         res["API"]["chart_type"] = self.chart["chart_type"]
+        res["API"]["line_variables"] = {}
 
         # Builds the line config
-        if self.chart_type == "LINE" : 
-            line_types = self.chart['chart_variables']['line_type']
-            for idx, i in enumerate(list(line_types.values())) :
-                res['API']['line_variables'][f'y{idx + 1 }'] = i
+        if self.chart_type == "LINE":
+            line_types = self.chart["chart_variables"]["line_type"]
+            for idx, i in enumerate(list(line_types.values())):
+                res["API"]["line_variables"][f"y{idx + 1 }"] = i
 
         return res["API"]
-    
+
     """
     Returns converted stacked values from abs to perc
     """
+
     def abs_to_perc(self, df_given):
         temp = df_given.copy()
-        temp['total'] = temp[self.b_y].sum(axis=1)
+        temp["total"] = temp[self.b_y].sum(axis=1)
         for c in self.b_y:
-            temp[c] = temp[c]/temp['total']*100
-        temp.drop(['total'], axis=1, inplace=True)
+            temp[c] = temp[c] / temp["total"] * 100
+        temp.drop(["total"], axis=1, inplace=True)
         return temp
-    
 
     """
     Builds the date slider
     """
-    def build_date_slider(self, df) :
+
+    def build_date_slider(self, df):
         df["date"] = df["date"].astype(str)
         options_list = df["date"].unique().tolist()
-        
+
         obj = {}
-        obj['key'] = "date_slider"
+        obj["key"] = "date_slider"
         obj["default"] = options_list[0]
-        obj["options"] = options_list 
+        obj["options"] = options_list
         obj["interval"] = self.data_frequency
 
-        return obj        
+        return obj
 
     """
     Returns the appropriate y-values
     """
-    def get_y_values(self) :
+
+    def get_y_values(self):
         y_values = self.chart["chart_variables"]["format"]["y"]
 
-        if isinstance(y_values, str) :
+        if isinstance(y_values, str):
             return [y_values]
-        
+
         return y_values

--- a/data_gov_my/catalog_utils/catalog_variable_classes/CatalogueDataHandler.py
+++ b/data_gov_my/catalog_utils/catalog_variable_classes/CatalogueDataHandler.py
@@ -1,4 +1,6 @@
-from data_gov_my.catalog_utils.catalog_variable_classes.Generalv2 import GeneralChartsUtil
+from data_gov_my.catalog_utils.catalog_variable_classes.Generalv2 import (
+    GeneralChartsUtil,
+)
 
 import pandas as pd
 import numpy as np
@@ -7,21 +9,22 @@ from dateutil.relativedelta import relativedelta
 from mergedeep import merge
 from data_gov_my.utils import translations as translation
 
-class CatalogueDataHandler() :
 
+class CatalogueDataHandler:
     # Default mappings for area-types
     _default_mapping = {
-        "state" : translation.STATE_TRANSLATIONS,
-        "parlimen" : translation.PARLIMEN_TRANSLATIONS,
-        "district" : translation.DISTRICT_TRANSLATIONS,
-        "dun" : translation.DUN_TRANSLATIONS,
-        "range" : translation.RANGE_TRANSLATIONS
+        "state": translation.STATE_TRANSLATIONS,
+        "parlimen": translation.PARLIMEN_TRANSLATIONS,
+        "district": translation.DISTRICT_TRANSLATIONS,
+        "dun": translation.DUN_TRANSLATIONS,
+        "range": translation.RANGE_TRANSLATIONS,
     }
-    
+
     """
     Constructor
     """
-    def __init__(self, chart_type, data, params) :
+
+    def __init__(self, chart_type, data, params):
         self._chart_type = chart_type
         self._data = data
         self._params = params
@@ -29,56 +32,71 @@ class CatalogueDataHandler() :
     """
     Gets the results depending on which chart type
     """
-    def get_results(self) :
+
+    def get_results(self):
         # Families with same format
-        if self._chart_type in ['BAR','HBAR','STACKED_BAR', 'AREA', 'TIMESERIES', 'STACKED_AREA', 'PYRAMID', 'CHOROPLETH', 'GEOCHOROPLETH', "GEOPOINT", "SCATTER"] :
+        if self._chart_type in [
+            "BAR",
+            "HBAR",
+            "LINE",
+            "STACKED_BAR",
+            "AREA",
+            "TIMESERIES",
+            "STACKED_AREA",
+            "PYRAMID",
+            "CHOROPLETH",
+            "GEOCHOROPLETH",
+            "GEOPOINT",
+            "SCATTER",
+        ]:
             return self.array_value_handler()
-        elif self._chart_type in ['HEATTABLE', "TABLE"] :
+        elif self._chart_type in ["HEATTABLE", "TABLE"]:
             return self.table_view_handler()
-        elif self._chart_type in ['GEOJSON'] :
+        elif self._chart_type in ["GEOJSON"]:
             return self.geo_data_handler()
 
     """
     Handles chart type Geodata
     """
-    def geo_data_handler(self) :
-        lang = self.default_param_value('lang', 'en', self._params)
+
+    def geo_data_handler(self):
+        lang = self.default_param_value("lang", "en", self._params)
 
         res = {}
         intro = self._data["chart_details"]["intro"]
         translations = self._data["translations"]
 
         self.extract_lang(lang)
-        self.set_translations(lang, translations, []) # Assuming no filters
+        self.set_translations(lang, translations, [])  # Assuming no filters
 
         res["intro"] = self.extract_lang_intro(lang, intro)
 
         self._data["chart_details"] = res
         return self._data
 
-
     """
     Handles charts with a table view, E.g : 
     1. Heatmap
     """
-    def table_view_handler(self) :
-        lang = self.default_param_value('lang', 'en', self._params)
+
+    def table_view_handler(self):
+        lang = self.default_param_value("lang", "en", self._params)
 
         intro = self._data["chart_details"]["intro"]
         translations = self._data["translations"]
-        chart_data = self._data["chart_details"]["chart"] # should put as chart_data(?)
+        chart_data = self._data["chart_details"]["chart"]  # should put as chart_data(?)
 
-        if self._chart_type == "TABLE" :
+        if self._chart_type == "TABLE":
             chart_data = chart_data
 
         defaults_api = {}
 
-        for d in self._data["API"]["filters"]: # Gets all the default API values
+        for d in self._data["API"]["filters"]:  # Gets all the default API values
             defaults_api[d["key"]] = d["default"]
 
         for k, v in defaults_api.items():
             key = self._params[k][0] if k in self._params else v
-            if key in chart_data :
+            if key in chart_data:
                 chart_data = chart_data[key]
             else:
                 chart_data = {}
@@ -86,49 +104,51 @@ class CatalogueDataHandler() :
 
         self.extract_lang(lang)
         self.set_translations(lang, translations, self._data["API"]["filters"])
-        
+
         res = {}
 
-        if self._chart_type == "TABLE" :
+        if self._chart_type == "TABLE":
             res["table_data"] = chart_data
-        else : 
+        else:
             res["chart_data"] = chart_data
-        
+
         res["intro"] = self.extract_lang_intro(lang, intro)
 
         self._data["chart_details"] = res
 
         return self._data
 
-    '''
+    """
     This handler supports of type : 
     1. Bar : BAR, HBAR, STACKED_BAR
     2. Timeseries : TIMESERIES, AREA, STACKED_AREA
-    '''
-    def array_value_handler(self) :
-        lang = self.default_param_value('lang', 'en', self._params)
+    """
+
+    def array_value_handler(self):
+        lang = self.default_param_value("lang", "en", self._params)
 
         intro = self._data["chart_details"]["intro"]  # Get intro
         translations = self._data["translations"]
         table_data = self._data["chart_details"]["chart"]["table_data"]
-        chart_data = self._data["chart_details"]["chart"]["chart_data"]  # Get chart data
+        chart_data = self._data["chart_details"]["chart"][
+            "chart_data"
+        ]  # Get chart data
 
-        defaults_api = {} # Creates a default API
+        defaults_api = {}  # Creates a default API
 
-        for d in self._data["API"]["filters"]: # Gets all the default API values
+        for d in self._data["API"]["filters"]:  # Gets all the default API values
             defaults_api[d["key"]] = d["default"]
-
 
         for k, v in defaults_api.items():
             key = self._params[k][0] if k in self._params else v
-            if ( key in table_data ) and ( key in chart_data ):
+            if (key in table_data) and (key in chart_data):
                 table_data = table_data[key]
                 chart_data = chart_data[key]
             else:
                 table_data = {}
                 chart_data = {}
                 break
-        
+
         self.extract_lang(lang)
         self.set_translations(lang, translations, self._data["API"]["filters"])
 
@@ -138,83 +158,89 @@ class CatalogueDataHandler() :
         res["intro"] = self.extract_lang_intro(lang, intro)
 
         self._data["chart_details"] = res
-        
+
         return self._data
 
-    '''
+    """
     Check if a chart has a date range element
-    '''
-    def chart_has_date(self, api_data) :
-        if 'has_date' in api_data :
-            return api_data['has_date']
+    """
+
+    def chart_has_date(self, api_data):
+        if "has_date" in api_data:
+            return api_data["has_date"]
 
         return None
-    
-    '''
+
+    """
     Sets default if key isn't in request parameters
-    '''
-    def default_param_value(self, key, default, params) :
-        if key in params : 
+    """
+
+    def default_param_value(self, key, default, params):
+        if key in params:
             return params[key][0]
-        
+
         return default
-    
-    '''
+
+    """
     Extract languages in other parts of the meta
-    '''
-    def extract_lang(self, lang) :
+    """
+
+    def extract_lang(self, lang):
         temp = self._data["metadata"]["dataset_desc"][lang]
         self._data["metadata"]["dataset_desc"] = temp
 
         temp = self._data["explanation"][lang]
         self._data["explanation"] = temp
 
-        for j in ["in_dataset", "out_dataset"] :
-            if j in self._data["metadata"] : 
-                for i in self._data["metadata"][j] :
+        for j in ["in_dataset", "out_dataset"]:
+            if j in self._data["metadata"]:
+                for i in self._data["metadata"][j]:
                     desc = i[f"desc_{lang}"]
                     title = i[f"title_{lang}"]
                     i["desc"] = desc
                     i["title"] = title
-                    [ i.pop(k) for k in ["desc_en", "desc_bm", "title_en", "title_bm"]]
+                    [i.pop(k) for k in ["desc_en", "desc_bm", "title_en", "title_bm"]]
 
-    '''
+    """
     Extract languages from intro key
-    '''
-    def extract_lang_intro(self, lang, intro) :
+    """
+
+    def extract_lang_intro(self, lang, intro):
         lang_info = intro[lang]
         intro.pop("en")
         intro.pop("bm")
         intro.update(lang_info)
         return intro
 
-    '''
+    """
     Extracts the language from a table view
-    '''
-    def extract_lang_table_view(self, lang, keys, data) :        
-        for d in data : 
-            for k in keys : 
-                if f"{k}_{lang}" in d :
+    """
+
+    def extract_lang_table_view(self, lang, keys, data):
+        for d in data:
+            for k in keys:
+                if f"{k}_{lang}" in d:
                     d[k] = d[f"{k}_{lang}"]
-                for l in ["en", "bm"] :
-                    if f"{k}_{l}" in d : 
+                for l in ["en", "bm"]:
+                    if f"{k}_{l}" in d:
                         d.pop(f"{k}_{l}")
-        
+
         return data
 
     """
     Sets the appropriate translations : en / bm
     """
-    def set_translations(self, lang, trans_data, api_filters) :
+
+    def set_translations(self, lang, trans_data, api_filters):
         additional_filters = {}
 
-        for f in api_filters : 
-            if f["key"] in ["state", "parlimen", "district", "range"] :
-                additional_filters.update(self._default_mapping[ f["key"] ])
-        
+        for f in api_filters:
+            if f["key"] in ["state", "parlimen", "district", "range"]:
+                additional_filters.update(self._default_mapping[f["key"]])
+
         trans_data[lang].update(additional_filters)
 
-        if trans_data[lang] : 
+        if trans_data[lang]:
             self._data["translations"] = trans_data[lang]
-        else : 
+        else:
             self._data.pop("translations")


### PR DESCRIPTION
## Changes made:
1. Added `res["API"]["line_variables"] = {}` to `build_api_info()` to prevent KeyError
```py   
...      
res["API"]["filters"] = api_filters_inc
res["API"]["precision"] = self.precision
res["API"]["chart_type"] = self.chart["chart_type"]
res["API"]["line_variables"] = {} # added this

# Builds the line config
if self.chart_type == "LINE":
    line_types = self.chart["chart_variables"]["line_type"]
    for idx, i in enumerate(list(line_types.values())):
        res["API"]["line_variables"][f"y{idx + 1 }"] = I # throws KeyError without added line

return res["API"]
```

2. Added `LINE` to `CatalogueDataHandler.get_results()` to prevent NoneError and instead correctly call `self.array_value_handler()` 