### PR TITLE
Hotfix/metrics table

### DIFF
--- a/data_gov_my/utils/chart_builder.py
+++ b/data_gov_my/utils/chart_builder.py
@@ -630,7 +630,7 @@ def metrics_table(file_name: str, variables: MetricsTableVariables):
 
     if "date" in df.columns:
         df["date"] = pd.to_datetime(df["date"])
-        df["date"] = df["date"].values.astype(np.int64) // 10**6
+        df["date"] = df["date"].dt.strftime("%Y-%m-%d")
 
     df["u_groups"] = list(df[keys].itertuples(index=False, name=None))
     u_groups_list = df["u_groups"].unique().tolist()

--- a/data_gov_my/views.py
+++ b/data_gov_my/views.py
@@ -104,7 +104,7 @@ class DASHBOARD(APIView):
         if all(p in param_list for p in params_req):
             res = handle_request(param_list)
             res = handle.dashboard_additional_handling(param_list, res)
-            return JsonResponse(dict(res), safe=False)
+            return JsonResponse(res, safe=False)
         else:
             return JsonResponse({}, safe=False)
 


### PR DESCRIPTION
## Changes
1. ~~`TypeError: Object of type int64 is not JSON serializable` is hot-fixed by returning `dict(res)` instead of `res`.~~ Doesn't seem to be the right fix, and error seems to be gone? 
2. Pre-process metrics table builder `state` and `date` column for consistency. 