### PR TITLE
Refactor/name popularity

### DIFF
--- a/data_gov_my/explorers/NamePopularity.py
+++ b/data_gov_my/explorers/NamePopularity.py
@@ -73,7 +73,7 @@ class NAME_POPULARITY(General_Explorer):
         res = model_choice.objects.all().filter(name__in=s).values()
 
         fin = []  # Default is as a list
-        hidden = False
+
         if len(res) > 0:
             for i in res:
                 temp = {}


### PR DESCRIPTION
## Changes:
> 1) On the top section, the timeseries is an array of 10 values. Anytime 9/10 values are = 0, don't show a chart and instead show a popup: "To preserve privacy, timeseries data for this name is not displayed."
> 2) On the bottom section, anytime the number is less than 10, show n/a in the "Most Popular Decade" column.

Per above requirements, changes have been made:
- res["data"] is only returned if `hidden` is False, `hidden` is set to True if the count array has only 1 positive value (indicating that the name can be traced to a single year).
- the `max` value is set to False if (2), FE should handle accordingly and show "N/A".

Additionally, `min` data is removed as it is now deprecated on FE.

