### PR TITLE
Fix/kawasanku admin

### DIFF
--- a/data_gov_my/api_handling/handle.py
+++ b/data_gov_my/api_handling/handle.py
@@ -26,5 +26,6 @@ def dashboard_additional_handling(params: QueryDict, res: dict):
             temp = jitter_data["chart_data"]["data"]["state"]
             res.setdefault("jitter_chart", {"data": None})
             res["jitter_chart"]["data"] = temp
+            res["jitter_chart"]["data_as_of"] = jitter_data["chart_data"]["data_as_of"]
             return res
     return res


### PR DESCRIPTION
## Changes
1. Directly grab the DashboardJson object for the jitter chart data, since `res` no longer has the jitter_chart information due to BE changes previously.
2. To prevent raising exceptions during the `get_nested_data()` operation, `optional_params` should be used instead of `required_params` for kawasanku APIs in the meta repo (done in staging prior to this PR)