### PR TITLE
Fix/dc

### DIFF
--- a/data_gov_my/catalog_utils/catalog_variable_classes/Generalv2.py
+++ b/data_gov_my/catalog_utils/catalog_variable_classes/Generalv2.py
@@ -302,6 +302,7 @@ class GeneralChartsUtil:
 
     def build_catalog_data_info(self):
         res = {}
+        res["openapi_id"] = self.file_src
         res["API"] = self.api
         res["explanation"] = self.explanation
         res["metadata"] = self.metadata


### PR DESCRIPTION
## Changes made:
1. ensure that `link_preview` must be a valid string (that evaluates to True) to be read, previous bug - ignored`link_parquet` due to `link_preview` key being present, but doesn't contain any value.
2. add `openapi_id` in API response for FE to use as the `id` value in OpenAPI sample query section. This `id` is equivalent to the filename of the catalogue metajson in meta repo, e.g. `labourforce_monthly` in `labourforce_monthly.json`