### PR TITLE
feat: annotate "total_downloads" for Publication

### DIFF
--- a/data_gov_my/serializers.py
+++ b/data_gov_my/serializers.py
@@ -92,6 +92,8 @@ class PublicationDetailSerializer(serializers.ModelSerializer):
 
 
 class PublicationSerializer(serializers.ModelSerializer):
+    total_downloads = serializers.IntegerField()
+
     class Meta:
         model = Publication
         fields = [
@@ -100,6 +102,7 @@ class PublicationSerializer(serializers.ModelSerializer):
             "title",
             "description",
             "release_date",
+            "total_downloads",
         ]
 
 

--- a/data_gov_my/views.py
+++ b/data_gov_my/views.py
@@ -6,7 +6,7 @@ from threading import Thread
 
 import environ
 from django.core.cache import cache
-from django.db.models import F, Q
+from django.db.models import F, Q, Sum
 from django.http import JsonResponse, QueryDict
 from django.shortcuts import get_list_or_404, get_object_or_404
 from django.utils.timezone import get_current_timezone
@@ -496,7 +496,9 @@ class PUBLICATION(generics.ListAPIView):
             raise ParseError(
                 detail=f"Please ensure `language` query parameter is provided with either en-GB or ms-MY as the value."
             )
-        return Publication.objects.filter(language=language)
+        return Publication.objects.filter(language=language).annotate(
+            total_downloads=Sum("resources__downloads")
+        )
 
     def filter_queryset(self, queryset):
         # apply filters


### PR DESCRIPTION
## Changes made
Show the total downloads of each publication (sum of the downloads for each relevant resources) via adding `total_downloads` key to the `publication/` endpoint.