### PR TITLE
Feat/filter view count get

### DIFF
--- a/data_gov_my/serializers.py
+++ b/data_gov_my/serializers.py
@@ -67,6 +67,16 @@ class ViewCountSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
+class ViewCountPartialSerializer(serializers.ModelSerializer):
+    """
+    Only returns the `view_count` field for metrics based fields.
+    """
+
+    class Meta:
+        model = ViewCount
+        exclude = ["download_csv", "download_parquet", "download_png", "download_svg"]
+
+
 class ViewCountSerializerV2(serializers.ModelSerializer):
     class Meta:
         model = ViewCount

--- a/data_gov_my/views.py
+++ b/data_gov_my/views.py
@@ -48,6 +48,7 @@ from data_gov_my.serializers import (
     PublicationSerializer,
     PublicationUpcomingSerializer,
     ViewCountSerializer,
+    ViewCountPartialSerializer,
     i18nSerializer,
 )
 from data_gov_my.utils import cron_utils
@@ -418,10 +419,15 @@ class FORMS(generics.ListAPIView):
 
 
 class VIEW_COUNT(APIView):
-    def get(self, request, format=None):
-        return JsonResponse(
-            ViewCountSerializer(ViewCount.objects.all(), many=True).data, safe=False
-        )
+    def get(self, request: request.Request, format=None):
+        views_only = request.query_params.get("views_only", "").lower() == "true"
+        serializer = ViewCountPartialSerializer if views_only else ViewCountSerializer
+        type = request.query_params.get("type")
+        if type:
+            queryset = ViewCount.objects.filter(type=type)
+        else:
+            queryset = ViewCount.objects.all()
+        return JsonResponse(serializer(queryset, many=True).data, safe=False)
 
     def post(self, request, format=None):
         id = request.query_params.get("id", None)


### PR DESCRIPTION
## Changes Made
FE requested the following changes to GET `view-count/` endpoint:
* `views_only` param - if `true`, the only metrics field returned is `view_count` 
* `type` param - used to filter the ViewCount objects (e.g. `type=dashboard`)