### PR TITLE
feat: add pub resource downloads GET endpoint

### DIFF
--- a/data_gov_my/urls.py
+++ b/data_gov_my/urls.py
@@ -42,6 +42,10 @@ urlpatterns = [
     ),
     path("publication/", views.PUBLICATION.as_view(), name="PUBLICATION"),
     path(
+        "publication-resource/downloads",
+        views.get_publication_resource_downloads,
+    ),
+    path(
         "publication-resource/<str:id>",
         views.PUBLICATION_RESOURCE.as_view(),
         name="PUBLICATION",

--- a/data_gov_my/views.py
+++ b/data_gov_my/views.py
@@ -545,6 +545,18 @@ class PUBLICATION_RESOURCE(generics.RetrieveAPIView):
         return pub_object
 
 
+@api_view(["GET"])
+def get_publication_resource_downloads(request):
+    cols = ["pub_id", "resource_id", "downloads"]
+    queryset = (
+        PublicationResource.objects.filter(publication__language="en-GB")
+        .annotate(pub_id=F("publication__publication_id"))
+        .values(*cols)
+        .order_by(*cols)
+    )
+    return Response(queryset, status=status.HTTP_200_OK)
+
+
 @api_view(["POST"])
 def publication_resource_download(request: request.Request):
     if request.query_params.get("documentation_type", "").lower() == "true":


### PR DESCRIPTION
## Changes made
Added a GET endpoint `publication-resource/downloads` that returns a list of publication resource downloads in the following format:
```json
[
    {
        "resource_id": 1,
        "downloads": 0,
        "pub_id": "cpi-2022-07"
    },
    {
        "resource_id": 2,
        "downloads": 0,
        "pub_id": "cpi-2022-07"
    },
]
```

The queryset is filtered by `language=en-GB`, since both languages are meant to return the same results.
