### PR TITLE
Fix/delete removed meta

### DIFF
--- a/data_gov_my/admin.py
+++ b/data_gov_my/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from data_gov_my.models import (
     CatalogJson,
+    ExplorersUpdate,
     FormData,
     FormTemplate,
     PublicationDocumentation,
@@ -27,3 +28,4 @@ admin.site.register(PublicationDocumentation)
 admin.site.register(PublicationDocumentationResource)
 admin.site.register(PublicationUpcoming)
 admin.site.register(CatalogJson)
+admin.site.register(ExplorersUpdate)

--- a/data_gov_my/management/commands/loader.py
+++ b/data_gov_my/management/commands/loader.py
@@ -53,5 +53,12 @@ class Command(BaseCommand):
             "UPDATE",
             "REBUILD",
         ]:
+            if operation == "REBUILD" and category in [
+                "PUBLICATION",
+                "PUBLICATION_DOCS",
+            ]:
+                raise InterruptedError(
+                    "REBUILD operation is not allowed for models that contain `download` field. Please delete the objects individually to avoid data loss!"
+                )
             builder = GeneralMetaBuilder.create(property=category)
             builder.build_operation(manual=True, rebuild=rebuild, meta_files=files)

--- a/data_gov_my/models.py
+++ b/data_gov_my/models.py
@@ -229,6 +229,9 @@ class ExplorersUpdate(models.Model):
     file_name = models.CharField(max_length=100, null=False)
     last_update = models.CharField(max_length=100, null=False)
 
+    def __str__(self) -> str:
+        return f"{self.explorer} ({self.file_name})"
+
 
 class Publication(models.Model):
     publication_id = models.CharField(max_length=30)

--- a/data_gov_my/utils/cron_utils.py
+++ b/data_gov_my/utils/cron_utils.py
@@ -87,45 +87,6 @@ def get_latest_info_git(type, commit_id):
         triggers.send_telegram("!!! FAILED TO GET GITHUB " + type + " !!!")
 
 
-def remove_deleted_files():
-    """
-    Remove deleted files.
-    """
-    for k, v in common.REFRESH_VARIABLES.items():
-        model_name = apps.get_model("data_gov_my", k)
-        distinct_db = [
-            m[v["column_name"]]
-            for m in model_name.objects.values(v["column_name"]).distinct()
-        ]
-        DIR = os.path.join(
-            os.getcwd(),
-            "DATAGOVMY_SRC/" + os.getenv("GITHUB_DIR", "-") + v["directory"],
-        )
-        distinct_dir = [
-            f.replace(".json", "") for f in listdir(DIR) if isfile(join(DIR, f))
-        ]
-        diff = list(set(distinct_db) - set(distinct_dir))
-
-        if diff:
-            # Remove the deleted datasets
-            query = {v["column_name"] + "__in": diff}
-            del_int, deleted = model_name.objects.filter(**query).delete()
-            logging.warning(f"Deleted removed files: {deleted}")
-
-    # Update the cache
-    source_filters_cache()
-    catalog_list = list(
-        CatalogJson.objects.all().values(
-            "id",
-            "catalog_name",
-            "catalog_category",
-            "catalog_category_name",
-            "catalog_subcategory_name",
-        )
-    )
-    cache.set("catalog_list", catalog_list)
-
-
 def get_fe_url_by_site(site):
     """
     Returns the URL and authorization header for frontend revalidation.

--- a/data_gov_my/utils/meta_builder.py
+++ b/data_gov_my/utils/meta_builder.py
@@ -632,6 +632,16 @@ class ExplorerBuilder(GeneralMetaBuilder):
     GITHUB_DIR = "explorers"
     VALIDATOR = ExplorerValidateModel
 
+    def delete_file(self, filename: str, data: dict):
+        meta_count, meta_deleted = MetaJson.objects.filter(
+            dashboard_name=data.get("explorer_name")
+        ).delete()
+        explorer_count, explorer_deleted = ExplorersUpdate.objects.filter(
+            explorer=data.get("explorer_name")
+        ).delete()
+        meta_deleted.update(explorer_deleted)
+        return meta_count + explorer_count, meta_deleted
+
     def update_or_create_meta(self, filename: str, metadata: ExplorerValidateModel):
         updated_values = {
             "dashboard_meta": metadata.model_dump(),

--- a/data_gov_my/utils/meta_builder.py
+++ b/data_gov_my/utils/meta_builder.py
@@ -587,6 +587,15 @@ class DataCatalogBuilder(GeneralMetaBuilder):
     GITHUB_DIR = "catalog"
     VALIDATOR = DataCatalogValidateModel
 
+    def delete_file(self, filename: str, data: dict):
+        file = data["file"]
+        bucket = file.get("bucket", "")
+        file_name = file.get("file_name", "")
+
+        return CatalogJson.objects.filter(
+            id__contains=f"{bucket}_{file_name}_"
+        ).delete()
+
     def update_or_create_meta(self, filename: str, metadata: DataCatalogValidateModel):
         file_data = metadata.file
         all_variable_data = metadata.file.variables

--- a/data_gov_my/utils/meta_builder.py
+++ b/data_gov_my/utils/meta_builder.py
@@ -137,7 +137,7 @@ class GeneralMetaBuilder(ABC):
         refreshed = GeneralMetaBuilder.refresh_meta_repo()
 
         if not refreshed:
-            logging.warning("Github repo has not been refreshed, abort building")
+            logger.warning("Github repo has not been refreshed, abort building")
         else:
             # build operation (for newly created or modified files)
             filtered_changes = cls.filter_changed_files(
@@ -531,6 +531,10 @@ class i18nBuilder(GeneralMetaBuilder):
     MODEL = i18nJson
     GITHUB_DIR = "i18n"
     VALIDATOR = i18nValidateModel
+
+    def delete_file(self, filename: str, data: dict):
+        logger.warning(f"Please handle deleting {filename} from S3")
+        return 0, {}
 
     def get_meta_files(self):
         """

--- a/data_gov_my/utils/meta_builder.py
+++ b/data_gov_my/utils/meta_builder.py
@@ -746,6 +746,14 @@ class PublicationBuilder(GeneralMetaBuilder):
     GITHUB_DIR = "pub-dosm/publications"
     VALIDATOR = PublicationValidateModel
 
+    def delete_file(self, filename: str, data: dict):
+        """
+        This will also delete the download counts for relevant publication resource!
+        """
+        return Publication.objects.filter(
+            publication_id=data.get("publication")
+        ).delete()
+
     def update_or_create_meta(self, filename: str, metadata: PublicationValidateModel):
         # english publication
         pub_object_en, _ = Publication.objects.update_or_create(
@@ -815,6 +823,14 @@ class PublicationDocumentationBuilder(GeneralMetaBuilder):
     MODEL = PublicationDocumentation
     GITHUB_DIR = "pub-dosm/documentation"
     VALIDATOR = PublicationDocumentationValidateModel
+
+    def delete_file(self, filename: str, data: dict):
+        """
+        This will also delete the download counts for relevant publication documentation resource!
+        """
+        return PublicationDocumentation.objects.filter(
+            publication_id=data.get("publication")
+        ).delete()
 
     def update_or_create_meta(
         self, filename: str, metadata: PublicationDocumentationValidateModel
@@ -887,6 +903,12 @@ class PublicationUpcomingBuilder(GeneralMetaBuilder):
     MODEL = PublicationUpcoming
     GITHUB_DIR = "pub-dosm/upcoming"
     VALIDATOR = PublicationUpcomingValidateModel
+
+    def delete_file(self, filename: str, data: dict):
+        """
+        Deletes the whole table because only a single file is supposed to reside within pub-dosm/upcoming
+        """
+        return PublicationUpcoming.objects.all().delete()
 
     def update_or_create_meta(
         self, filename: str, metadata: PublicationUpcomingValidateModel

--- a/data_gov_my/utils/meta_builder.py
+++ b/data_gov_my/utils/meta_builder.py
@@ -416,6 +416,16 @@ class DashboardBuilder(GeneralMetaBuilder):
     GITHUB_DIR = "dashboards"
     VALIDATOR = DashboardValidateModel
 
+    def delete_file(self, file: dict):
+        meta_count, meta_deleted = MetaJson.objects.filter(
+            dashboard_name=file.get("dashboard_name")
+        ).delete()
+        dashboard_count, dashboard_deleted = DashboardJson.objects.filter(
+            dashboard_name=file.get("dashboard_name")
+        ).delete()
+        meta_deleted.update(dashboard_deleted)
+        return meta_count + dashboard_count, meta_deleted
+
     def update_or_create_meta(self, filename: str, metadata: DashboardValidateModel):
         dashboard_meta = metadata.model_dump()
         updated_values = {


### PR DESCRIPTION
## Changes made
The previous `remove_deleted_files()` method was used to delete dashboard and data catalogue metajsons that have been removed within a single commit. This was done by comparing the difference before and after "refreshing" the github repo, e.g. `list(set(distinct_db) - set(distinct_dir))`. 
As the current meta_builder needs to support other categories, e.g. explorer, publications, forms etc., the deleting logic is refactored to rely on the [Github API response](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit), where the status of the file change is checked - `["added","removed","modified","renamed","copied","changed","unchanged"]`.

1. `cron_utils.remove_deleted_files()` is deprecated and removed.

3. `meta_builder.selective_update()` keeps track of `changed_files` (status != removed) and `deleted_files` (status == removed), performs usual build_operation using `changed_files`, then performs delete operation using `deleted_files`.
    * the github api response contains a `raw_url` that points to the file content deleted, this json file is parsed and used to filter which files to be deleted, e.g. `Publication.objects.filter(publication_id=data.get("publication")).delete()`, where `data` is the parsed json file.
  
## Considerations
1. `i18n` is now pushed to S3, current PR does not support deleting i18n from the S3 bucket, it will just be skipped.
2. `PublicationUpcoming` is built based on a single metajson (which contains the parquet, where 1 row = 1 model object). If this file is removed, it is assumed that the DB table will be wiped. 
3. Due to `download` field in `Publication` and `PublicationDocumentation`, the REBUILD operation will wipe all of the download metrics data, hence an error is raised when using the `loader` command.

