### PR TITLE
Hotfix/dc filter

### DIFF
--- a/data_gov_my/catalog_utils/catalog_variable_classes/CatalogueDataHandler.py
+++ b/data_gov_my/catalog_utils/catalog_variable_classes/CatalogueDataHandler.py
@@ -202,6 +202,7 @@ class CatalogueDataHandler:
             first_filter = self._data["API"]["filters"][0]["key"]
             start_idx = 1 if first_filter == "date_slider" else 0
 
+        key_list = []  # keeps track of selected filter so far
         for idx, d in enumerate(self._data["API"]["filters"]):
             if (idx > start_idx) and (d["key"] != "range"):
                 prev_param = self._data["API"]["filters"][
@@ -209,13 +210,16 @@ class CatalogueDataHandler:
                 ]  # Take from previous selection
                 if prev_param["key"] in self._params:
                     choice = self._params[prev_param["key"]][0]
+                    key_list.append(choice)
                     if choice in d["options"]:
                         d["options"] = d["options"][choice]
                         d["default"] = d["options"][0]
                     else:
                         self._data["API"]["filters"].remove(d)
                 else:
-                    d["options"] = d["options"][prev_param["default"]]
+                    # d["options"] = d["options"][prev_param["default"]]
+                    key_list.append(prev_param["default"])
+                    d["options"] = self.get_nested_dict_by_list(d["options"], key_list)
 
     """
     Check if a chart has a date range element

--- a/data_gov_my/catalog_utils/catalog_variable_classes/CatalogueDataHandler.py
+++ b/data_gov_my/catalog_utils/catalog_variable_classes/CatalogueDataHandler.py
@@ -8,6 +8,8 @@ import json
 from dateutil.relativedelta import relativedelta
 from mergedeep import merge
 from data_gov_my.utils import translations as translation
+from functools import reduce  # forward compatibility for Python 3
+import operator
 
 
 class CatalogueDataHandler:
@@ -32,6 +34,10 @@ class CatalogueDataHandler:
     """
     Gets the results depending on which chart type
     """
+
+    @staticmethod
+    def get_nested_dict_by_list(nested_dict: dict, key_list: list):
+        return reduce(operator.getitem, key_list, nested_dict)
 
     def get_results(self):
         # Families with same format

--- a/data_gov_my/catalog_utils/catalog_variable_classes/CatalogueDataHandler.py
+++ b/data_gov_my/catalog_utils/catalog_variable_classes/CatalogueDataHandler.py
@@ -153,17 +153,17 @@ class CatalogueDataHandler:
         ]  # Get chart data
 
         defaults_api = {}  # Creates a default API
-        prev_key = ""
+        prev_key = []
 
         for d in self._data["API"]["filters"]:  # Gets all the default API values
             key = d["key"]
             val = ""
             if key not in ["date_slider", "range"]:
-                if prev_key == "" or key in self._params:  # The first key
+                if not prev_key or key in self._params:  # The first key
                     val = self._params[key][0] if key in self._params else d["default"]
                 else:
-                    val = d["options"][defaults_api[prev_key]][0]
-                prev_key = key
+                    val = self.get_nested_dict_by_list(d["options"], prev_key)[0]
+                prev_key.append(val)
             else:
                 val = self._params[key][0] if key in self._params else d["default"]
             defaults_api[key] = val

--- a/data_gov_my/catalog_utils/catalog_variable_classes/Pyramidv2.py
+++ b/data_gov_my/catalog_utils/catalog_variable_classes/Pyramidv2.py
@@ -217,7 +217,7 @@ class Pyramid(GeneralChartsUtil):
                     )
                     cur_level = dropdown
                     for dk in default_key:
-                        cur_level = dropdown[dk]
+                        cur_level = cur_level[dk]
                     def_key = cur_level[0]
                     filter_obj = self.build_api_object_filter(
                         key=api, def_val=def_key, options=dropdown

--- a/data_gov_my/catalog_utils/catalog_variable_classes/Timeseriesv2.py
+++ b/data_gov_my/catalog_utils/catalog_variable_classes/Timeseriesv2.py
@@ -383,7 +383,7 @@ class Timeseries(GeneralChartsUtil):
                     )
                     cur_level = dropdown
                     for dk in default_key:
-                        cur_level = dropdown[dk]
+                        cur_level = cur_level[dk]
                     def_key = cur_level[0]
                     filter_obj = self.build_api_object_filter(
                         key=api, def_val=def_key, options=dropdown


### PR DESCRIPTION
## Changes made
### Nested chart data
Currently, data catalogue is unable to handle > 2 SLICE_BY keys (dependent dropdowns to filter chart_data). This is primarily due to the architecture of filtering the chart datas by SLICE_BY keys: chart data is stored in a nested format, to get to the correct chart data by filter values (SLICE_BY keys), the code must traverse through the nested dictionary. BE seems to have an issue of correctly traversing through the nested dictionary. 

This PR uses [`get_nested_dict_by_list()`](https://stackoverflow.com/questions/14692690/access-nested-dictionary-items-via-a-list-of-keys) to hotfix the buggy traversal of nested chart data.

### Catalogue Chart builders 
In `build_api_info()`, the fix below is applied to Timeseries and Pyramid chart.
```py
  cur_level = dropdown
  for dk in default_key:
      # cur_level = dropdown[dk] ## (deleted line)
      cur_level = cur_level[dk] ## correct line
```

## Considerations
* In general, I think it would be good to rethink the architecture for filtering chart data. We should avoid using this nested data approach as the complexity is dependent on the filter combination and will easily get out of hand.
* For other chart builders, the `cur_level = cur_level[dk]` change is not applied yet. Should incrementally fix it in case we find a better approach first!