### PR TITLE
fix: dc list query param validation

### DIFF
--- a/data_catalogue/views.py
+++ b/data_catalogue/views.py
@@ -40,8 +40,8 @@ class DataCatalogueListAPIView(APIView):
         frequency = request.query_params.get("frequency", "")
         geography = request.query_params.getlist("geography", [])
         demography = request.query_params.getlist("demography", [])
-        dataset_begin = request.query_params.get("dataset_begin", "")
-        dataset_end = request.query_params.get("dataset_end", "")
+        dataset_begin = request.query_params.get("start", "")
+        dataset_end = request.query_params.get("end", "")
 
         # Prepare filter conditions based on query parameters
         filters = Q()
@@ -53,10 +53,10 @@ class DataCatalogueListAPIView(APIView):
             filters &= Q(geography__overlap=geography)
         if demography:
             filters &= Q(demography__overlap=demography)
-        if dataset_begin:
-            filters &= Q(dataset_begin__gte=dataset_begin)
-        if dataset_end:
-            filters &= Q(dataset_end__lte=dataset_end)
+        if dataset_begin and dataset_begin.isdigit():
+            filters &= Q(dataset_begin__gte=int(dataset_begin))
+        if dataset_end and dataset_end.isdigit():
+            filters &= Q(dataset_end__lte=int(dataset_end))
 
         # Query the SiteCategory objects with related DataCatalogueMeta
         site_categories = (


### PR DESCRIPTION
## Changes Made
Checks if number type query params are digits before casting to int and passing to Django's ORM to filter.