### PR TITLE
feat: thumbnail required for approved products

### DIFF
--- a/community_product/models.py
+++ b/community_product/models.py
@@ -76,6 +76,8 @@ class CommunityProduct(models.Model):
             for field in translate_fields:
                 if not getattr(self, field + "_ms"):
                     errors[field + "_ms"] = "This field is required."
+            if not self.thumbnail:
+                errors["thumbnail"] = "This field is required."
 
         elif self.status == "rejected":
             if not self.remark_en:


### PR DESCRIPTION
## Changes Made
Validate `thumbnail` to be non-empty when admins try to save a community product status as "approved". 