### PR TITLE
Feat/publication search

### DIFF
--- a/data_gov_my/views.py
+++ b/data_gov_my/views.py
@@ -527,6 +527,13 @@ class PUBLICATION_UPCOMING_LIST(generics.ListAPIView):
 
     def filter_queryset(self, queryset):
         # apply filters
+        search = self.request.query_params.get("search")
+        if search:
+            queryset = queryset.filter(
+                Q(publication_title__icontains=search)
+                | Q(publication_type_title__icontains=search)
+            )
+
         pub_type = self.request.query_params.get("pub_type")
         if pub_type:
             queryset = queryset.filter(publication_type__iexact=pub_type)

--- a/data_gov_my/views.py
+++ b/data_gov_my/views.py
@@ -44,6 +44,7 @@ from data_gov_my.serializers import (
     i18nSerializer,
 )
 from data_gov_my.utils.meta_builder import GeneralMetaBuilder
+from django.db.models import Q
 
 env = environ.Env()
 environ.Env.read_env()
@@ -339,6 +340,12 @@ class PUBLICATION(generics.ListAPIView):
         )
 
     def filter_queryset(self, queryset):
+        search = self.request.query_params.get("search")
+        if search:
+            queryset = queryset.filter(
+                Q(title__icontains=search) | Q(description__icontains=search)
+            )
+
         # apply filters
         pub_type = self.request.query_params.get("pub_type")
         if pub_type:

--- a/data_gov_my/views.py
+++ b/data_gov_my/views.py
@@ -469,6 +469,14 @@ class PUBLICATION_DOCS(generics.ListAPIView):
             .order_by("publication_id")
         )
 
+    def filter_queryset(self, queryset):
+        search = self.request.query_params.get("search")
+        if search:
+            queryset = queryset.filter(
+                Q(title__icontains=search) | Q(description__icontains=search)
+            )
+        return queryset
+
 
 class PUBLICATION_DOCS_RESOURCE(generics.RetrieveAPIView):
     serializer_class = PublicationDetailSerializer


### PR DESCRIPTION
## Changes Made
Instead of filtering by publication type with exact matching, `search` query param is introduced to publications, upcoming publications and technical notes (publication documentation) endpoints that perform a case insensitive partial match to relevant fields (e.g. title OR description). Existing query params are all still available. 