### PR TITLE
fix: parse multiple geo/demog filters properly

### DIFF
--- a/data_catalogue/views.py
+++ b/data_catalogue/views.py
@@ -38,8 +38,8 @@ class DataCatalogueListAPIView(APIView):
         # Extract additional query parameters
         data_source = request.query_params.getlist("source", [])
         frequency = request.query_params.get("frequency", "")
-        geography = request.query_params.getlist("geography", [])
-        demography = request.query_params.getlist("demography", [])
+        geography = request.query_params.get("geography", "")
+        demography = request.query_params.get("demography", "")
         dataset_begin = request.query_params.get("begin", "")
         dataset_end = request.query_params.get("end", "")
         search = request.query_params.get("search", "")
@@ -51,8 +51,10 @@ class DataCatalogueListAPIView(APIView):
         if frequency:
             filters &= Q(frequency=frequency)
         if geography:
+            geography = geography.split(",")
             filters &= Q(geography__overlap=geography)
         if demography:
+            demography = demography.split(",")
             filters &= Q(demography__overlap=demography)
         if dataset_begin and dataset_begin.isdigit():
             filters &= Q(dataset_begin__gte=int(dataset_begin))


### PR DESCRIPTION
## Changes Made
Query param was not working as expected due to inconsistent formatting and parsing of query param.
* `request.query_params.getlist("geography", [])` returns `["a", "b"]` for `?param=a&param=b`, but does not process `param=a,b` - instead it reads as `["a,b"]`. 
* This is updated by retrieving the param as a single string and splitting if necessary. 