### PR TITLE
Refactor/remove redundant fields

### DIFF
--- a/data_gov_my/utils/meta_builder.py
+++ b/data_gov_my/utils/meta_builder.py
@@ -451,11 +451,11 @@ class DashboardBuilder(GeneralMetaBuilder):
             "sites": metadata.sites,
         }
         obj, created = MetaJson.objects.update_or_create(
-            dashboard_name=metadata.dashboard_name,
+            dashboard_name=Path(filename).stem,
             defaults=updated_values,
         )
 
-        cache.set("META_" + metadata.dashboard_name, dashboard_meta)
+        cache.set("META_" + Path(filename).stem, dashboard_meta)
         return obj
 
     def additional_handling(

--- a/data_gov_my/utils/meta_builder.py
+++ b/data_gov_my/utils/meta_builder.py
@@ -435,10 +435,10 @@ class DashboardBuilder(GeneralMetaBuilder):
 
     def delete_file(self, filename: str, data: dict):
         meta_count, meta_deleted = MetaJson.objects.filter(
-            dashboard_name=data.get("dashboard_name")
+            dashboard_name=Path(filename).stem
         ).delete()
         dashboard_count, dashboard_deleted = DashboardJson.objects.filter(
-            dashboard_name=data.get("dashboard_name")
+            dashboard_name=Path(filename).stem
         ).delete()
         meta_deleted.update(dashboard_deleted)
         return meta_count + dashboard_count, meta_deleted

--- a/data_gov_my/utils/metajson_structures.py
+++ b/data_gov_my/utils/metajson_structures.py
@@ -17,7 +17,6 @@ SITES = Literal["datagovmy", "kkmnow", "opendosm", "databnm"]
 
 
 class DashboardChartModel(BaseModel):
-    name: str
     chart_type: str
     chart_source: str
     data_as_of: str
@@ -64,7 +63,6 @@ class DashboardChartModel(BaseModel):
 
 
 class DashboardValidateModel(BaseModel):
-    dashboard_name: str
     data_last_updated: datetime
     data_next_update: Optional[datetime] = None
     route: str


### PR DESCRIPTION
## Changes Made
Remove redundant fields:
* Directly use filename of dashboard metas, instead of `dashboard_name` key value
* Directly use charts dictionary keys' names as chart id, instead of `chart_name` key value