### PR TITLE
Fix/community product from email

### DIFF
--- a/community_product/admin.py
+++ b/community_product/admin.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.contrib import admin
 from django.utils import translation, timezone
 from modeltranslation.admin import TranslationAdmin
@@ -47,6 +48,7 @@ class CommunityProductAdmin(TranslationAdmin):
             with translation.override(obj.language):
                 try:
                     mail.send(
+                        sender=settings.DATA_GOV_MY_FROM_EMAIL,
                         recipients=obj.email,
                         language=obj.language,
                         template=self.COMMUNITY_PRODUCT_APPROVED_TEMPLATE,
@@ -54,6 +56,7 @@ class CommunityProductAdmin(TranslationAdmin):
                             name=obj.name,
                             product_name=getattr(obj, f"product_name_{obj.language}"),
                         ),
+                        backend="datagovmy_ses",
                     )
                 except Exception as e:
                     logging.error(e)
@@ -62,6 +65,7 @@ class CommunityProductAdmin(TranslationAdmin):
             with translation.override(obj.language):
                 try:
                     mail.send(
+                        sender=settings.DATA_GOV_MY_FROM_EMAIL,
                         recipients=obj.email,
                         language=obj.language,
                         template=self.COMMUNITY_PRODUCT_REJECTED_TEMPLATE,
@@ -70,6 +74,7 @@ class CommunityProductAdmin(TranslationAdmin):
                             product_name=getattr(obj, f"product_name_{obj.language}"),
                             reason=getattr(obj, f"remark_{obj.language}"),
                         ),
+                        backend="datagovmy_ses",
                     )
                 except Exception as e:
                     logging.error(e)

--- a/data_gov_my/backends.py
+++ b/data_gov_my/backends.py
@@ -6,14 +6,14 @@ from django.core.mail.backends.base import BaseEmailBackend
 from botocore.exceptions import BotoCoreError, ClientError
 
 
-class DataRequestEmailBackend(BaseEmailBackend):
+class DataGovMYSESBackend(BaseEmailBackend):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.client = boto3.client(
             'ses',
             region_name=settings.AWS_SES_REGION_NAME,
-            aws_access_key_id=settings.AWS_SES_ACCESS_KEY_ID_DATA_REQUEST,
-            aws_secret_access_key=settings.AWS_SES_SECRET_ACCESS_KEY_DATA_REQUEST,
+            aws_access_key_id=settings.AWS_SES_ACCESS_KEY_ID_DATA_GOV_MY,
+            aws_secret_access_key=settings.AWS_SES_SECRET_ACCESS_KEY_GOV_MY,
         )
 
     def send_messages(self, email_messages):

--- a/data_gov_my/settings.py
+++ b/data_gov_my/settings.py
@@ -215,7 +215,7 @@ EMAIL_BACKEND = "post_office.EmailBackend"
 EMAIL_HOST = os.getenv("EMAIL_HOST")
 EMAIL_PORT = os.getenv("EMAIL_PORT")
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL")
-DEFAULT_FROM_EMAIL_DATA_REQUEST = os.getenv("DEFAULT_FROM_EMAIL_DATA_REQUEST")
+DATA_GOV_MY_FROM_EMAIL = os.getenv("DATA_GOV_MY_FROM_EMAIL")
 EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
 EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
 EMAIL_USE_SSL = os.getenv("EMAIL_USE_SSL")
@@ -226,13 +226,13 @@ POST_OFFICE = {"CELERY_ENABLED": True}
 if not DEBUG:
     POST_OFFICE["BACKENDS"] = {
         "default": "django_ses.SESBackend",
-        "data_request": "data_request.backends.DataRequestEmailBackend",
+        "datagovmy_ses": "data_gov_my.backends.DataGovMYSESBackend"
     }
     # django-ses
     AWS_SES_ACCESS_KEY_ID = os.getenv("AWS_SES_ACCESS_KEY_ID")
-    AWS_SES_ACCESS_KEY_ID_DATA_REQUEST = os.getenv("AWS_SES_ACCESS_KEY_ID_DATA_REQUEST")
+    AWS_SES_ACCESS_KEY_ID_DATA_GOV_MY = os.getenv("AWS_SES_ACCESS_KEY_ID_DATA_GOV_MY")
     AWS_SES_SECRET_ACCESS_KEY = os.getenv("AWS_SES_SECRET_ACCESS_KEY")
-    AWS_SES_SECRET_ACCESS_KEY_DATA_REQUEST = os.getenv("AWS_SES_SECRET_ACCESS_KEY_DATA_REQUEST")
+    AWS_SES_SECRET_ACCESS_KEY_DATA_GOV_MY = os.getenv("AWS_SES_SECRET_ACCESS_KEY_DATA_GOV_MY")
     USE_SES_V2 = os.getenv("USE_SES_V2")
     AWS_SES_REGION_NAME = os.getenv("AWS_SES_REGION_NAME")
     AWS_SES_REGION_ENDPOINT = os.getenv("AWS_SES_REGION_ENDPOINT")

--- a/data_gov_my/views.py
+++ b/data_gov_my/views.py
@@ -8,6 +8,7 @@ from threading import Thread
 
 import environ
 import requests
+from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
@@ -323,10 +324,12 @@ class FORMS(generics.ListAPIView):
             recipient = form_data.get_recipient()
             if recipient:
                 email = mail.send(
+                    sender=settings.DATA_GOV_MY_FROM_EMAIL,
                     recipients=recipient,
                     template=template.email_template,
                     language=form_data.language,
                     context=form_data.form_data,
+                    backend="datagovmy_ses",
                 )
                 form_data.email = email
                 form_data.save(update_fields=["email"])

--- a/data_request/admin.py
+++ b/data_request/admin.py
@@ -99,12 +99,12 @@ class DataRequestAdmin(TranslationAdmin):
             email_context.update(context)
             if recipients.exists():
                 mail.send(
-                    sender=settings.DEFAULT_FROM_EMAIL_DATA_REQUEST,
+                    sender=settings.DATA_GOV_MY_FROM_EMAIL,
                     recipients=list(recipients),
                     template=template,
                     language="en-GB",
                     context=email_context,
-                    backend="data_request",
+                    backend="datagovmy_ses",
                 )
 
         with translation.override("ms"):
@@ -115,12 +115,12 @@ class DataRequestAdmin(TranslationAdmin):
             email_context.update(context)
             if recipients.exists():
                 mail.send(
-                    sender=settings.DEFAULT_FROM_EMAIL_DATA_REQUEST,
+                    sender=settings.DATA_GOV_MY_FROM_EMAIL,
                     recipients=list(recipients),
                     template=template,
                     language="ms-MY",
                     context=email_context,
-                    backend="data_request",
+                    backend="datagovmy_ses",
                 )
 
     def save_model(self, request: Any, obj: Any, form: Any, change: Any) -> None:
@@ -138,12 +138,12 @@ class DataRequestAdmin(TranslationAdmin):
             with translation.override("ms"):
                 context = DataRequestSerializer(obj).data
                 mail.send(
-                    sender=settings.DEFAULT_FROM_EMAIL_DATA_REQUEST,
+                    sender=settings.DATA_GOV_MY_FROM_EMAIL,
                     recipients=obj.agency.emails,
                     template=self.DATA_REQUEST_AGENCY_NOTIFICATION_TEMPLATE,
                     language="ms",
                     context=context,
-                    backend="data_request",
+                    backend="datagovmy_ses",
                 )
         elif obj.status in ["rejected", "data_published"]:
             obj.date_completed = timezone.now()

--- a/data_request/management/commands/run_email_backend.py
+++ b/data_request/management/commands/run_email_backend.py
@@ -6,19 +6,25 @@ from django.core.management.base import BaseCommand
 
 from post_office import mail
 
+
 class Command(BaseCommand):
     help = "Test email backend"
 
     def handle(self, *args, **options):
+        recipients_env = os.environ.get("TEST_EMAIL_RECIPIENTS", "")
+        recipients = tuple(
+            email.strip() for email in recipients_env.split(",") if email.strip()
+        )
+        print(recipients)
         mail.send(
-            recipients=('juwaini@gmail.com'),
-            subject='test default mail send',
-            message='test default mail send',
+            recipients=recipients,
+            subject="test default mail send",
+            message="test default mail send",
         )
         mail.send(
-            sender=settings.DEFAULT_FROM_EMAIL_DATA_REQUEST,
-            recipients=('juwaini@gmail.com'),
-            subject='test data request',
-            message='test data request',
-            backend='data_request',
+            sender=settings.DATA_GOV_MY_FROM_EMAIL,
+            recipients=recipients,
+            subject="test data request",
+            message="test data request",
+            backend="datagovmy_ses",
         )

--- a/data_request/views.py
+++ b/data_request/views.py
@@ -50,7 +50,7 @@ class SubscriptionCreateAPIView(generics.CreateAPIView):
         # send email to notify subscription
         try:
             mail.send(
-                sender=settings.DEFAULT_FROM_EMAIL_DATA_REQUEST,
+                sender=settings.DATA_GOV_MY_FROM_EMAIL,
                 recipients=email,
                 bcc=bcc_list,
                 language=serializer.validated_data["language"],
@@ -67,7 +67,7 @@ class SubscriptionCreateAPIView(generics.CreateAPIView):
                     ),
                     "agency": data_request.agency,
                 },
-                backend="data_request",
+                backend="datagovmy_ses",
             )
         except Exception as e:
             logging.error(e)
@@ -111,13 +111,13 @@ class DataRequestCreateAPIView(generics.CreateAPIView):
             context = serializer.data
             context["name"] = data.get("name")
             email = mail.send(
-                sender=settings.DEFAULT_FROM_EMAIL_DATA_REQUEST,
+                sender=settings.DATA_GOV_MY_FROM_EMAIL,
                 recipients=recipient,
                 bcc=bcc_list,
                 language=email_lang,
                 template=self.FORM_TYPE,
                 context=context,
-                backend="data_request",
+                backend="datagovmy_ses",
             )
         except Exception as e:
             logging.error(e)


### PR DESCRIPTION
- Rename email backend from "data_request" to "datagovmy_ses" to make it clearer that the emails are sent from datagovmy's email
- Update community product emails to use datagovmy_ses email backend